### PR TITLE
Specification of the JSON structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 Have a question? Discuss the quantized-mesh specification on the [Cesium community forum](https://community.cesium.com/).
 
-A terrain tileset in quantized-mesh-1.0 format is a simple multi-resolution quadtree pyramid of meshes. All tiles have the extension .terrain. So, if the Tiles URL for a tileset is:
+A terrain tileset in quantized-mesh-1.0 format is a simple multi-resolution quadtree pyramid of meshes.
+
+The structure of this pyramid is defined in a `layer.json` file. The format of this file is described in the [`SPECIFICATION.md`](./SPECIFICATION.md]). This file contains information about the URL at which the actual terrain tiles can be requested. For example, when the URL for a tileset is
 
 ```
 http://example.com/tiles
 ```
 
-Then the two root files of the pyramid are found at these URLs:
+then then the two root files of the pyramid may be found at these URLs:
 
-* (-180 deg, -90 deg) - (0 deg, 90 deg) - http://example.com/tiles/0/0/0.terrain
-* (0 deg, -90 deg) - (180 deg, 90 deg) - http://example.com/tiles/0/1/0.terrain
+* (-180 deg, -90 deg) - (0 deg, 90 deg) - `http://example.com/tiles/0/0/0.terrain`
+* (0 deg, -90 deg) - (180 deg, 90 deg) - `http://example.com/tiles/0/1/0.terrain`
 
-The eight tiles at the next level are found at these URLs:
+The eight tiles at the next level are then found at these URLs:
 
-* (-180 deg, -90 deg) - (-90 deg, 0 deg) - http://example.com/tiles/1/0/0.terrain
-* (-90 deg, -90 deg) - (0 deg, 0 deg) - http://example.com/tiles/1/1/0.terrain
-* (0 deg, -90 deg) - (90 deg, 0 deg) - http://example.com/tiles/1/2/0.terrain
-* (90 deg, -90 deg) - (180 deg, 0 deg) - http://example.com/tiles/1/3/0.terrain
-* (-180 deg, 0 deg) - (-90 deg, 90 deg) - http://example.com/tiles/1/0/1.terrain
-* (-90 deg, 0 deg) - (0 deg, 90 deg) - http://example.com/tiles/1/1/1.terrain
-* (0 deg, 0 deg) - (90 deg, 90 deg) - http://example.com/tiles/1/2/1.terrain
-* (90 deg, 0 deg) - (180 deg, 90 deg) - http://example.com/tiles/1/3/1.terrain
+* (-180 deg, -90 deg) - (-90 deg, 0 deg) - `http://example.com/tiles/1/0/0.terrain`
+* (-90 deg, -90 deg) - (0 deg, 0 deg) - `http://example.com/tiles/1/1/0.terrain`
+* (0 deg, -90 deg) - (90 deg, 0 deg) - `http://example.com/tiles/1/2/0.terrain`
+* (90 deg, -90 deg) - (180 deg, 0 deg) - `http://example.com/tiles/1/3/0.terrain`
+* (-180 deg, 0 deg) - (-90 deg, 90 deg) - `http://example.com/tiles/1/0/1.terrain`
+* (-90 deg, 0 deg) - (0 deg, 90 deg) - `http://example.com/tiles/1/1/1.terrain`
+* (0 deg, 0 deg) - (90 deg, 90 deg) - `http://example.com/tiles/1/2/1.terrain`
+* (90 deg, 0 deg) - (180 deg, 90 deg) - `http://example.com/tiles/1/3/1.terrain`
 
 When requesting tiles, be sure to include the following HTTP header in the request:
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Have a question? Discuss the quantized-mesh specification on the [Cesium communi
 
 A terrain tileset in quantized-mesh-1.0 format is a simple multi-resolution quadtree pyramid of meshes.
 
-The structure of this pyramid is defined in a `layer.json` file. The format of this file is described in the [`SPECIFICATION.md`](./SPECIFICATION.md]). This file contains information about the URL at which the actual terrain tiles can be requested. For example, when the URL for a tileset is
+The structure of this pyramid is defined in a `layer.json` file. The format of this file is described in the [`SPECIFICATION.md`](./SPECIFICATION.md). This file contains information about the URL at which the actual terrain tiles can be requested. For example, when the URL for a tileset is
 
 ```
 http://example.com/tiles

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The structure of this pyramid is defined in a `layer.json` file. The format of t
 http://example.com/tiles
 ```
 
-then then the two root files of the pyramid may be found at these URLs:
+then the two root files of the pyramid may be found at these URLs:
 
 * (-180 deg, -90 deg) - (0 deg, 90 deg) - `http://example.com/tiles/0/0/0.terrain`
 * (0 deg, -90 deg) - (180 deg, 90 deg) - `http://example.com/tiles/0/1/0.terrain`
@@ -108,7 +108,7 @@ Once decoded, the meaning of a value in each array is as follows:
 | Field | Meaning |
 | ----- | ------- |
 | u | The horizontal coordinate of the vertex in the tile. When the u value is 0, the vertex is on the Western edge of the tile. When the value is 32767, the vertex is on the Eastern edge of the tile. For other values, the vertex's longitude is a linear interpolation between the longitudes of the Western and Eastern edges of the tile. |
-| v | The vertical coordinate of the vertex in the tile. When the v value is 0, the vertex is on the Southern edge of the tile. When the value is 32767, the vertex is on the Northern edge of the tile. For other values, the vertex's latitude is a linear interpolation between the latitudes of the Southern and Nothern edges of the tile. |
+| v | The vertical coordinate of the vertex in the tile. When the v value is 0, the vertex is on the Southern edge of the tile. When the value is 32767, the vertex is on the Northern edge of the tile. For other values, the vertex's latitude is a linear interpolation between the latitudes of the Southern and Northern edges of the tile. |
 | height | The height of the vertex in the tile. When the height value is 0, the vertex's height is equal to the minimum height within the tile, as specified in the tile's header. When the value is 32767, the vertex's height is equal to the maximum height within the tile. For other values, the vertex's height is a linear interpolation between the minimum and maximum heights. |
 
 Immediately following the vertex data is the index data. Indices specify how the vertices are linked together into triangles. If tile has more than 65536 vertices, the tile uses the `IndexData32` structure to encode indices. Otherwise, it uses the `IndexData16` structure.
@@ -200,7 +200,7 @@ struct ExtensionHeader
 }
 ```
 
-As new extensions are defined, they will be assigned a unique identifier. If no extensions are defined for the tileset, an `ExtensionHeader` will not included in the quanitzed-mesh. Multiple extensions may be appended to the quantized-mesh data, where ordering of each extension is determined by the server.
+As new extensions are defined, they will be assigned a unique identifier. If no extensions are defined for the tileset, an `ExtensionHeader` will not included in the quantized-mesh. Multiple extensions may be appended to the quantized-mesh data, where ordering of each extension is determined by the server.
 
 Multiple extensions may be requested by the client by delimiting extension names with a `-`. For example, a client can request vertex normals and watermask using the following Accept header:
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,56 @@
+
+# JSON Format Specification
+
+This section describes the format of the `layer.json` manifest file. The format is derived from [tilejson](https://github.com/mapbox/tilejson-spec), but is not a strict subset of this format. The JSON schema for this file can be found in [`layer.schema.json`](./schema/layer.schema.json). The following table summarizes the properties that can be contained in this JSON file, their data types, default values, and interpretation:
+
+
+| *Property* | *Type* | *Description* | *Required* |
+|---|---|---|---|
+| name | `string` | The name of this terrain tileset. | No. Default: `"Terrain"` |
+| description | `string` | The description of this terrain tileset. | No. Default: `""` |
+| attribution | `string` | The attribution (credit) string for the terrain. | No. Default: `""` |
+| version | `string` | The version of this tileset. | No. Default: `"1.0.0"` |
+| format | `string` | The format of the terrain tiles. Should be `"quantized-mesh-1.0"`. | No. Default: `"quantized-mesh-1.0"` |
+| scheme | `string` | The tiling scheme. The only valid value is `"tms"`. | No. Default: `"tms"` |
+| extensions | `string[]` | The extensions available for this tileset. | No. Default: `undefined` |
+| projection | `string` | The map projection of this tileset. Valid values are `"EPSG:4326"` and `"EPSG:3857"`. | No. Default: `"EPSG:4326"` |
+| parentUrl | `string` | The URL of the parent layer.json that this one is layered on top of. | No. Default: `undefined` |
+| minzoom | `integer` | The minimum level for which there are any available tiles. | No. Default: `0` |
+| maxzoom | `integer` | The maximum level for which there are any available tiles. | Yes |
+| bounds | `number[4]` | The bounding box of the terrain, expressed as `[west, south, east, north]`, in degrees. This is not required for calculating tile positions or downloads. Implementations may choose to ignore this property. | No. Default: `[-180,-90,180,90]` |
+| tiles | `string[]` | The URL templates from which to obtain tiles. | Yes |
+| available | `availabilityRectangle[][]` | The tile availability information. The outer array is indexed by tile level. The inner array is a list of rectangles of availability at that level. Tiles themselves may also contain further availability information for their subtree. If `metadataAvailability` is present, then this property should be ignored. | No. Default: `undefined` |
+| metadataAvailability | `integer` | The levels at which metadata is found in tiles. A value of `n` indicates that metadata can be found at every `n`th level, starting at 0. For example, if this value is 10, then metadata is found at levels 0, 10, 20, etc. If this property is present, then the `available` property should be ignored.| No. Default: `undefined` |
+
+## About `available` and `metadataAvailability`
+
+The `available` property is a predecessor of what is now stored in the `metadataAvailability`. When the `metadataAvailability` is present, then the `available` property should be ignored. Specifically: When the `metadataAvailability` is present, then the structure of the `available` property may not properly reflect the actual availability. 
+
+## About `tiles`
+
+The `tiles` property is an array of template URLs. This array should have a length of exactly 1. Clients may choose to ignore all but the first array element. The template URLs can contain variables `{x}`, `{y}`, `{z}`, and `{version}`. The `{z}` variable indicates the level of the tile. The `{x}` and `{y}` variables indicate the x- and y coordinate of the tile. The `version` indicator is a hint for clients or users to indicate whether the underlying data changed over time. When clients or users are caching the data in any form, then a change in the version number should cause that cache to be invalidated.
+
+An example of the entry of the `tiles` array is 
+`"{z}/{x}/{y}.terrain?v={version}"`
+At runtime, this will be converted into an actual URL by substituting the template variables accordingly - for example:
+`5/46/21.terrain?v=1.2.0`
+
+## About `extensions`
+
+The `extensions` is an array of strings that indicate different flavors of the data that may be requested. The elements of this array can be added as query parameters in the request, with the key being `extensions`, and the value being the names of the desired extensions, separated by a `-` dash. For example, when the layer JSON indicates extensions
+```json
+"extensions": [
+    "watermask",
+    "metadata",
+    "octvertexnormals"
+]
+```
+then the query parameter can be
+`extensions=octvertexnormals-watermask-metadata`
+The request URL (including the substituted template variables) and these parameters would therefore be
+`12/6074/2684.terrain?extensions=octvertexnormals-watermask-metadata&v=1.2.0`
+
+## About `minzoom`
+
+While the value of `minzoom` can technically be greater than 0, some details of the behavior are not clearly specified for this case. Many clients will ignore the `minzoom` value, and assume the availability information to be present for layer 0.
+

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -54,3 +54,17 @@ The request URL (including the substituted template variables) and these paramet
 
 While the value of `minzoom` can technically be greater than 0, some details of the behavior are not clearly specified for this case. Many clients will ignore the `minzoom` value, and assume the availability information to be present for layer 0.
 
+## About the refinement process
+
+_This section is non-normative!_
+
+Client implementations will usually traverse the tile hierarchy for a quantized mesh, replacing the rendered representation of one tile with its child tiles, until the desired refinement level is achieved. During this process, the availability of child tiles is checked with the `available`- or `metadataAvailability` properties. The availability will be looked up either directly, or via the layer information that is found under the `parentUrl`.
+
+During this process, it can happen that only a _some_ of the four children of a given parent tile are marked as being available.
+
+Clients have different options for handling this case:
+
+- Clients _could_ omit the child tiles that are not available. This would cause gaps in the visual representation of the tiles, and is therefore not recommended
+- Clients can take the geometry of the parent tile, split it into four parts, and use the respective parts from the parent geometry to fill the gaps that would otherwise be caused by children that are not available
+- Clients can generate artificial "fill tiles" to fill the gaps. These tiles will usually be generated at runtime, by aligning the borders with the geometry of the surrounding tiles, and interpolating the vertex heights bilinearly between the heights of the border vertices.
+

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -60,7 +60,7 @@ _This section is non-normative!_
 
 Client implementations will usually traverse the tile hierarchy for a quantized mesh, replacing the rendered representation of one tile with its child tiles, until the desired refinement level is achieved. During this process, the availability of child tiles is checked with the `available`- or `metadataAvailability` properties. The availability will be looked up either directly, or via the layer information that is found under the `parentUrl`.
 
-During this process, it can happen that only a _some_ of the four children of a given parent tile are marked as being available.
+During this process, it can happen that only _some_ of the four children of a given parent tile are marked as being available.
 
 Clients have different options for handling this case:
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -14,7 +14,7 @@ This section describes the format of the `layer.json` manifest file. The format 
 | scheme | `string` | The tiling scheme. The only valid value is `"tms"`. | No. Default: `"tms"` |
 | extensions | `string[]` | The extensions available for this tileset. | No. Default: `undefined` |
 | projection | `string` | The map projection of this tileset. Valid values are `"EPSG:4326"` and `"EPSG:3857"`. | No. Default: `"EPSG:4326"` |
-| parentUrl | `string` | The URL of the parent layer.json that this one is layered on top of. | No. Default: `undefined` |
+| parentUrl | `string` | The URL of the parent layer.json that this one is layered on top of. When this is defined, then availability information and the presence of extensions should also be looked up in the parent. Attributions from parents should be integrated into the overall attribution. | No. Default: `undefined` |
 | minzoom | `integer` | The minimum level for which there are any available tiles. | No. Default: `0` |
 | maxzoom | `integer` | The maximum level for which there are any available tiles. | Yes |
 | bounds | `number[4]` | The bounding box of the terrain, expressed as `[west, south, east, north]`, in degrees. This is not required for calculating tile positions or downloads. Implementations may choose to ignore this property. | No. Default: `[-180,-90,180,90]` |

--- a/schema/availabilityRectangle.schema.json
+++ b/schema/availabilityRectangle.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "availabilityRectangle.schema.json",
+  "title": "AvailabilityRectangle",
+  "description": "A rectangle of tile availability.",
+  "properties": {
+    "startX": {
+      "description": "The index of the start tile in the X direction.",
+      "type": "integer"
+    },
+    "startY": {
+      "description": "The index of the start tile in the Y direction.",
+      "type": "integer"
+    },
+    "endX": {
+      "description": "The index of the end tile in the X direction.",
+      "type": "integer"
+    },
+    "endY": {
+      "description": "The index of the end tile in the Y direction.",
+      "type": "integer"
+    }
+  },
+  "required": ["startX", "startY", "endX", "endY"]
+}

--- a/schema/layer.schema.json
+++ b/schema/layer.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "layer.schema.json",
+  "title": "Layer",
+  "description": "A quantized-mesh terrain layer.json.",
+  "properties": {
+    "attribution": {
+      "description": "The attribution (credit) string for the terrain.",
+      "type": "string",
+      "default": ""
+    },
+    "available": {
+      "description": "The tile availability information. The outer array is indexed by tile level. The inner array is a list of rectangles of availability at that level. Tiles themselves may also contain further availability information for their subtree.",
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "availabilityRectangle.schema.json"
+        }
+      }
+    },
+    "bounds": {
+      "description": "The bounding box of the terrain, expressed as west, south, east, north in degrees.",
+      "type": "array",
+      "default": [-180,-90,180,90],
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "type": "number"
+      }
+    },
+    "description": {
+      "description": "The description of this terrain tileset.",
+      "type": "string",
+      "default": ""
+    },
+    "extensions": {
+      "description": "The extensions available for this tileset.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "format": {
+      "description": "The format of the terrain tiles. Should be `\"quantized-mesh-1.0\"`.",
+      "type": "string",
+      "default": "quantized-mesh-1.0"
+    },
+    "maxzoom": {
+      "description": "The maximum level for which there are any available tiles.",
+      "type": "integer"
+    },
+    "minzoom": {
+      "description": "The minimum level for which there are any available tiles.",
+      "type": "integer",
+      "default": 0
+    },
+    "metadataAvailability": {
+      "description": "The levels at which metadata is found in tiles. For example, if this value is 10, then metadata is found at levels 0, 10, 20, etc.",
+      "type": "integer"
+    },
+    "name": {
+      "description": "The name of this terrain tileset.",
+      "type": "string",
+      "default": "Terrain"
+    },
+    "parentUrl": {
+      "description": "The URL of the parent layer.json that this one is layered on top of.",
+      "type": "string"
+    },
+    "projection": {
+      "description": "The map projection of this tileset. Valid values are `\"EPSG:4326\"` and `\"EPSG:3857\"`.",
+      "type": "string",
+      "default": "EPSG:4326"
+    },
+    "scheme": {
+      "description": "The tiling scheme. The only valid value is `\"tms\"`.",
+      "type": "string",
+      "default": "tms"
+    },
+    "tiles": {
+      "description": "The URL templates from which to obtain tiles.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "version": {
+      "description": "The version of this tileset.",
+      "type": "string",
+      "default": "1.0.0"
+    }
+  },
+  "required": ["tiles", "maxzoom"]
+}


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/quantized-mesh/issues/15 , which has been open in one of my tabs for 5 years, and accumulated 10 👍 's in the meantime.

This is a first attempt to add a proper specification of the `layer.json` structure. As discussed in the issue, people have largely been reverse-engineering this information from the implementation. This is error-prone and involves too many guesses and assumptions.

The current state of this PR is certainly still not perfect in that regard. It only contains what I could derive from the implementation, links that had been posted in the issue, and the discussion that happened there. But maybe it is a reasonable first step for a proper specification.

Tagging some people who participated in the issue dicussion:

@lilleyse 
@kring (the schema here is largely copied from https://github.com/CesiumGS/cesium-native/blob/a42b513f05de5d2700ca1394985a622bca164184/CesiumQuantizedMeshTerrain/schema/layer.schema.json )
@gkjohnson 

